### PR TITLE
README.md: remove outdated info about dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,10 @@ working start:
 
 * *No* dependency on system libraries, beyond that which is required by other
   dependencies.
-* Anything which ships with GHC. *However*, we must retain compatibility with
-  versions of those packages going back to at least GHC 7.4, and preferably
-  earlier.
-* text, once again with backwards compatibility for versions included with
-  legacy Haskell Platform. In other words, 0.11.2 support is required.
-* network, support back to 2.3. We do *not* need to support the
-  network/network-bytestring split.
-* stm, preferably all the way back to 2.1.
-* transformers
+* Anything which ships with GHC (including `text`, `transformers`).
+* `network`
+* `stm`
 
 For debate:
 
-* Other Haskell Platform packages, especially vector and attoparsec.
+* Other Haskell Platform packages, especially `vector` and `attoparsec`.


### PR DESCRIPTION
Some information in the _Dependencies_ section is stale, overtaken by time.